### PR TITLE
DRM-28: fixed null pointer exception when dhis2 has no org units

### DIFF
--- a/omod/src/main/java/org/openmrs/module/dhisreport/web/controller/LocationMappingController.java
+++ b/omod/src/main/java/org/openmrs/module/dhisreport/web/controller/LocationMappingController.java
@@ -85,7 +85,7 @@ public class LocationMappingController {
 				log.debug("Error in Unmarshalling");
 				e.printStackTrace();
 			}
-			if (metadata != null) {
+			if (metadata != null && metadata.getOrganizationUnits() != null) {
 				ou = metadata.getOrganizationUnits().getOrganizationUnits();
 				model.addAttribute("orgunits", ou);
 


### PR DESCRIPTION
see:
https://issues.openmrs.org/browse/DRM-28