### PR TITLE
DRM-9 : startOfPeriod and endOfPeriod not there exception should be handled properly

### DIFF
--- a/api/src/main/java/org/openmrs/module/dhisreport/api/db/hibernate/HibernateDHIS2ReportingDAO.java
+++ b/api/src/main/java/org/openmrs/module/dhisreport/api/db/hibernate/HibernateDHIS2ReportingDAO.java
@@ -184,9 +184,22 @@ public class HibernateDHIS2ReportingDAO
         {
             query.setParameter( "locationId", location.getId().toString() );
         }
-        query.setParameter( "startOfPeriod", period.getStartDate() );
-        query.setParameter( "endOfPeriod", period.getEndDate() );
-        return query.uniqueResult().toString();
+        if ( parameters.contains( "startOfPeriod" ) )
+        {
+            query.setParameter( "startOfPeriod", period.getStartDate() );
+        }
+        if ( parameters.contains( "endOfPeriod" ) )
+        {
+            query.setParameter( "endOfPeriod", period.getEndDate() );
+        }
+        if ( !parameters.contains( "startOfPeriod" ) && !parameters.contains( "endOfPeriod" ) )
+        {
+            return "NoParam";
+        }
+        else
+        {
+            return query.uniqueResult().toString();
+        }
     }
 
     // --------------------------------------------------------------------------------------------------------------

--- a/omod/src/main/java/org/openmrs/module/dhisreport/web/controller/ReportController.java
+++ b/omod/src/main/java/org/openmrs/module/dhisreport/web/controller/ReportController.java
@@ -444,8 +444,15 @@ public class ReportController
         {
             DataValueType dvtype = new DataValueType();
             dvtype.setDataElement( dv.getDataElement() );
-            dvtype.setValue( new BigDecimal( dv.getValue() ) );
-            dvTypeList.add( dvtype );
+            try
+            {
+                BigDecimal bd = new BigDecimal( dv.getValue() );
+                dvtype.setValue( bd );
+                dvTypeList.add( dvtype );
+            }
+            catch ( NumberFormatException e )
+            {
+            }
         }
         gt.getDataValue().addAll( dvTypeList );
         gt.setOrgUnit( dvs.getOrgUnit() );

--- a/omod/src/main/resources/messages.properties
+++ b/omod/src/main/resources/messages.properties
@@ -101,3 +101,4 @@ ${project.parent.artifactId}.openMRSLocationDoesNotExist = OpenMRS Location Does
 ${project.parent.artifactId}.orgUnitCodeDoesNotExist = "Code" Attribute in DHIS2 ORG UNIT is not set. Please set it and then try Mapping.
 
 ${project.parent.artifactId}.editReportMapping = Edit Report Mapping
+${project.parent.artifactId}.missingParameters = Parameters missing

--- a/omod/src/main/webapp/executeReport.jsp
+++ b/omod/src/main/webapp/executeReport.jsp
@@ -36,7 +36,12 @@
     <tr>
   		<td>${dvm.key.name}</td>
   		<td>${dvm.key.code}</td>		
+  		<c:if test="${dvm.value!='NoParam'}">
   		<td>${dvm.value}</td>
+                </c:if>
+                <c:if test="${dvm.value=='NoParam'}">
+                <td><div id="openmrs_msg"><spring:message code="dhisreport.missingParameters" /> </div></td>
+                </c:if>
   	</tr>
 	<tr>
   	</c:forEach>


### PR DESCRIPTION
Show an alert message when an indicator does not contain parameters.