### PR TITLE
DRM-28: Map Location Page Crashes when DHIS2 Instance has no ORG Units

### DIFF
--- a/omod/src/main/java/org/openmrs/module/dhisreport/web/controller/LocationMappingController.java
+++ b/omod/src/main/java/org/openmrs/module/dhisreport/web/controller/LocationMappingController.java
@@ -119,13 +119,13 @@ public class LocationMappingController {
 
 	@RequestMapping(value = "/module/dhisreport/mapLocations", method = RequestMethod.POST)
 	public String mapLocations(ModelMap model,
-			@RequestParam(value = "DHIS2OrgUnits", required = true) String dhis2OrgUnitCode,
+			@RequestParam(value = "DHIS2OrgUnits", required = false) String dhis2OrgUnitCode,
 			@RequestParam(value = "openmrsLocations", required = true) String openmrsLocationName,
 			WebRequest webRequest) {
 		System.out.println("org unit does not  exits and it is : " + dhis2OrgUnitCode);
 		String referer = webRequest.getHeader("Referer");
 
-		if (dhis2OrgUnitCode.equals("")) {
+		if (dhis2OrgUnitCode == null || dhis2OrgUnitCode.isEmpty()) {
 			System.out.println("org unit does not  exits");
 			webRequest.setAttribute(WebConstants.OPENMRS_MSG_ATTR,
 					Context.getMessageSourceService().getMessage("dhisreport.orgUnitCodeDoesNotExist"),

--- a/omod/src/main/webapp/mapLocations.jsp
+++ b/omod/src/main/webapp/mapLocations.jsp
@@ -37,7 +37,7 @@
 	</table>
 </form>
 
-<tr>
+
 
 <h3>
 	<spring:message code="dhisreport.mappedLocations" />


### PR DESCRIPTION
DRM-28: Map Location Page Crashes when DHIS2 Instance has no ORG Unit
link:https://issues.openmrs.org/browse/DRM-28
I set the DHIS2OrgUnits value to false and also checked the null value 