### PR TITLE
DRM-46: 'Configure DHIS2 Connection' page crashes when trying to connect

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -75,14 +75,14 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
-			<version>4.2</version>
+			<version>4.4.13</version>
 			<type>jar</type>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.3.6</version>
+			<version>4.5.12</version>
 			<type>jar</type>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
## Description of what I changed
- Bumped httpclient from 4.3.6 to 4.5.12 in /api
- Bumped httpCore from 4.2 to 4.4.13 in /api

![PR](https://user-images.githubusercontent.com/33048395/77931617-03be8800-72ca-11ea-8656-39b4ea195937.gif)

## Issue I worked on
See https://issues.openmrs.org/browse/DRM-46